### PR TITLE
rm redundant when logger to new file

### DIFF
--- a/fnet/connectionmgr.go
+++ b/fnet/connectionmgr.go
@@ -35,6 +35,8 @@ func (this *ConnectionMgr) Remove(conn iface.Iconnection) error {
 }
 
 func (this *ConnectionMgr) Get(sid uint32) (iface.Iconnection, error) {
+	this.conMrgLock.Lock()
+	defer this.conMrgLock.Unlock()
 	v, ok := this.connections[sid]
 	if ok {
 		delete(this.connections, sid)
@@ -45,6 +47,8 @@ func (this *ConnectionMgr) Get(sid uint32) (iface.Iconnection, error) {
 }
 
 func (this *ConnectionMgr) Len() int {
+	this.conMrgLock.Lock()
+	defer this.conMrgLock.Unlock()
 	return len(this.connections)
 }
 

--- a/fnet/connectionmgr.go
+++ b/fnet/connectionmgr.go
@@ -35,8 +35,6 @@ func (this *ConnectionMgr) Remove(conn iface.Iconnection) error {
 }
 
 func (this *ConnectionMgr) Get(sid uint32) (iface.Iconnection, error) {
-	this.conMrgLock.Lock()
-	defer this.conMrgLock.Unlock()
 	v, ok := this.connections[sid]
 	if ok {
 		delete(this.connections, sid)
@@ -47,8 +45,6 @@ func (this *ConnectionMgr) Get(sid uint32) (iface.Iconnection, error) {
 }
 
 func (this *ConnectionMgr) Len() int {
-	this.conMrgLock.Lock()
-	defer this.conMrgLock.Unlock()
 	return len(this.connections)
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -284,7 +284,7 @@ func (f *_FILE) rename() {
 			t, _ := time.Parse(DATEFORMAT, time.Now().Format(DATEFORMAT))
 			f._date = &t
 			f.logfile, _ = os.Create(f.dir + "/" + f.filename)
-			f.lg = log.New(logObj.logfile, "\n", log.Ldate|log.Ltime|log.Lshortfile)
+			f.lg = log.New(logObj.logfile, "", log.Ldate|log.Ltime|log.Lshortfile)
 		}
 	} else {
 		f.coverNextOne()
@@ -305,7 +305,7 @@ func (f *_FILE) coverNextOne() {
 	}
 	os.Rename(f.dir+"/"+f.filename, f.dir+"/"+f.filename+"."+strconv.Itoa(int(f._suffix)))
 	f.logfile, _ = os.Create(f.dir + "/" + f.filename)
-	f.lg = log.New(logObj.logfile, "\n", log.Ldate|log.Ltime|log.Lshortfile)
+	f.lg = log.New(logObj.logfile, "", log.Ldate|log.Ltime|log.Lshortfile)
 }
 
 func fileSize(file string) int64 {


### PR DESCRIPTION
不恰当的\n当文件切换时，出现多余换行